### PR TITLE
fix: update Gatsby peer dependency for Gatsby 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"webpack": "^5.46.0"
 	},
 	"peerDependencies": {
-		"gatsby": "^4.1.2"
+		"gatsby": "^3 || ^4"
 	},
 	"engines": {
 		"node": ">=12.7.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"webpack": "^5.46.0"
 	},
 	"peerDependencies": {
-		"gatsby": "^3.10.1"
+		"gatsby": "^4.1.2"
 	},
 	"engines": {
 		"node": ">=12.7.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
I've upgraded the version of Gatsby that the addon uses to v4.1.2
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
In order for applications using the latest version of Gatsby to utilize this addon, this package needs to be upgraded to use the latest version of Gatsby as well. The version of Gatsby was set to the latest 4.X one.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
