### PR TITLE
feat: add Static Queries support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,12 @@ import { Configuration as WebpackConfiguration } from "webpack";
 type AddonOptions = Record<string, never>;
 
 /**
+ * This adds Gatsby's static queries directory to Storybook's assets. This is
+ * necessary to use Gatsby's `useStaticQuery()` or `<StaticQuery>`.
+ */
+export const staticDirs = ["page-data/sq/d"];
+
+/**
  * This adds a file necessary to make the preview environment compatible with Gatsby.
  *
  * @param entries Existing entries
@@ -45,9 +51,13 @@ export const webpackFinal = (
 			typeof config.module.rules[0].use[0].options === "object"
 		) {
 			// use babel-plugin-remove-graphql-queries to remove static queries from components when rendering in storybook
-			config.module.rules[0].use[0].options.plugins.push(
+			config.module.rules[0].use[0].options.plugins.push([
 				require.resolve("babel-plugin-remove-graphql-queries"),
-			);
+				{
+					stage: config.mode === `development` ? "develop-html" : "build-html",
+					staticQueryDir: "page-data/sq/d",
+				},
+			]);
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This adds Static Query support. It enables the use of Gatsby's `useStaticQuery()` and `<StaticQuery>` in Stories.

Gatsby's development server must be running for Static Queries to be available in Storybook. Alternatively, the Gatsby project can be built ahead of starting Storybook.

Related thread: https://community.prismic.io/t/storybook-addon-gatsby-how-to-override-options-in-babel-plugin-remove-graphql-queries-fix-loading-staticquery-in-storybook/8763

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
📕
