### PR TITLE
Include gatsby-script in transpiled gatsby modules regex

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export const webpackFinal = (
 ): WebpackConfiguration => {
 	if (typeof config.module?.rules?.[0] === "object") {
 		// Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
-		config.module.rules[0].exclude = [/node_modules\/(?!(gatsby)\/)/];
+		config.module.rules[0].exclude = [/node_modules\/(?!(gatsby|gatsby-script)\/)/];
 
 		if (
 			Array.isArray(config.module.rules[0].use) &&


### PR DESCRIPTION
Required change to add `gatsbt-script` to regex for transpiled modules

## Types of changes

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Resolves issue https://github.com/prismicio-community/storybook-addon-gatsby/issues/7 by including new dependency from gatsby in the exclude list

## Checklist:

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.
