### PR TITLE
Add an auto check for React version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Configuration as WebpackConfiguration } from "webpack";
-
+import React from "react"
 /**
  * Options for the addon. There are no options.
  */
@@ -37,6 +37,11 @@ export const webpackFinal = (
 	config: WebpackConfiguration,
 	_options: AddonOptions,
 ): WebpackConfiguration => {
+	// Use correct react-dom depending on React version.
+	if (parseInt(React.version) <= 18) {
+	    config.externals = ["react-dom/client"];
+	}
+	
 	if (typeof config.module?.rules?.[0] === "object") {
 		// Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
 		config.module.rules[0].exclude = [/node_modules\/(?!(gatsby)\/)/];


### PR DESCRIPTION
This allows React 16 17 and 18 to work automatically.

See this discussion for example problem:

https://github.com/gatsbyjs/gatsby/discussions/36293

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
This allows users to use this addon with any React version and ensure the right `react-dom` is used.  

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
