### PR TITLE
fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "ssh://git@github.com/prismicio-community/storybook-addon-gatsby.git"
+		"url": "git+https://github.com/prismicio-community/storybook-addon-gatsby.git"
 	},
 	"license": "Apache-2.0",
 	"author": "Prismic <contact@prismic.io> (https://prismic.io)",


### PR DESCRIPTION
## Summary

- update the package repository URL from SSH to `git+https`

## Validation

- checked `package.json` parses and points to `git+https://github.com/prismicio-community/storybook-addon-gatsby.git`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
